### PR TITLE
Improve readability of faqs shadow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,3 +82,7 @@ background-image: none;
   padding: 0px;
   text-align: left;
 }
+
+.faqs-shadow{
+  box-shadow: 0px 5px 20px 4px lightgrey;
+}

--- a/src/components/faqs/FAQsComponent.tsx
+++ b/src/components/faqs/FAQsComponent.tsx
@@ -128,7 +128,7 @@ const FAQs = () => {
 
       {faqsClone.map((faq:Faq, index:number) => (
         <div className={`collapse rounded-md ${ 'mb-5'  // Agrega mb-5 si no es el último elemento
-          } shadow-xl`} key={index}>
+          } faqs-shadow`} key={index}>
 
           <input type="checkbox" className="peer" id={index.toString()}/>
           <div className="collapse-title relative flex rounded-b-md bg-white text-justify text-black text-4 font-poppins font-bold font-poppins peer-checked:bg-[#BA007C] peer-checked:rounded-b-[0px] peer-checked:text-secondary-content">


### PR DESCRIPTION
Task: [FE] Adjust the css shadow for FAQs to improve readability

Before:
<img width="635" alt="before" src="https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/120119395/cf5c6cba-9b19-41d6-8325-6898c91f04b3">

After:
<img width="642" alt="after" src="https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/120119395/25c86acb-dc71-4e87-b549-6c1f3539d245">
