### PR TITLE
feature/invite-layout-update

### DIFF
--- a/src/components/BackOfficeUserSendCode.tsx
+++ b/src/components/BackOfficeUserSendCode.tsx
@@ -1,7 +1,7 @@
-import { useState, useRef, useEffect } from "react"
-import resetIcon from "../assets/img/reset.svg"
-import checkIcon from "../assets/img/confirmationIcon.svg"
-import errorIcon from "../assets/img/error.svg"
+import { useState, useRef, useEffect } from "react";
+// import resetIcon from "../assets/img/reset.svg";
+import checkIcon from "../assets/img/confirmationIcon.svg";
+import errorIcon from "../assets/img/error.svg";
 import { handleSubmit } from "../store/reducers/apiCall/apiSendCodeByEmail";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../store/store";
@@ -11,129 +11,136 @@ import { useTranslation } from "react-i18next";
 
 const BackOfficeUserSendCode = () => {
   const [t] = useTranslation();
-  const dispatch = useDispatch()
+  const dispatch = useDispatch();
 
   const { acces_token }: createToken = useSelector(
     (state: RootState) => state.apiPostRegister
   );
 
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [colorInput, setColorInput] = useState("input-secondary");
-  const [colorButton, setColorButton] = useState('bg-[#BA007C]');
+  const [colorButton, setColorButton] = useState("bg-[#BA007C]");
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
-  const [desactivateInputElements, setDesactivateInputElements] = useState(false);
+  const [desactivateInputElements, setDesactivateInputElements] =
+    useState(false);
   const [showAlert, setShowAlert] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
-  const requestStatus = useSelector((state: RootState) => state.apiSendCodeByEmail.requestStatus);
+  const requestStatus = useSelector(
+    (state: RootState) => state.apiSendCodeByEmail.requestStatus
+  );
 
-  const validateEmail = (email:string) => {
-    const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/ 
-    return emailPattern.test(email)
-  }
+  const validateEmail = (email: string) => {
+    const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+    return emailPattern.test(email);
+  };
 
   const handleSendEmail = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (validateEmail(email)) {
-      setDesactivateInputElements(true)
+      setDesactivateInputElements(true);
       setError("none-error");
+      setIsLoading(true);
 
-      e.preventDefault()
-      try{
-        await handleSubmit(dispatch, email, acces_token)
-        setShowAlert(true)    
-        // requestStatus === '200' ? (setColorButton('btn-success'),  setColorInput('input-success'), console.log('dentro')) : (setColorButton('btn-error'), setColorInput('input-error'), console.log('fuera'))
+      e.preventDefault();
+      try {
+        await handleSubmit(dispatch, email, acces_token);
+        setShowAlert(true);
 
         setTimeout(() => {
-          handleResetEmail("reset-email")
+          handleResetEmail("reset-email");
+          setIsLoading(false);
           setShowAlert(false);
         }, 2000);
-
-      }catch(error){
-        handleResetEmail("reset-email")
-        console.error(error)
+      } catch (error) {
+        handleResetEmail("reset-email");
+        console.error(error);
       }
-
     } else {
       setError("ERROR");
-      setColorInput('input-error')
-      setColorButton('btn-error')
+      setColorButton("btn-error");
     }
   };
-  
-  const handleResetEmail = (resetEmail:string) => {
-    resetEmail === 'reset-email' ? setEmail("") : ''
-    setDesactivateInputElements(false)
+
+  // when we focus on the input this happens
+  const handleResetEmail = (resetEmail: string) => {
+    resetEmail === "reset-email" ? setEmail("") : "";
+    setDesactivateInputElements(false);
     setError("");
-    setColorInput('input-secondary')
-    setColorButton('bg-pink-it')
-    setShowAlert(false)
+    setColorButton("bg-pink-it");
+    setShowAlert(false);
     inputRef.current?.focus();
-  }
+  };
 
   useEffect(() => {
-    if(requestStatus === '200' && showAlert===true) {
-      setColorButton('btn-success')
-      setColorInput('input-success')
-    }else if(requestStatus === '404' && showAlert===true){
-      setColorButton('btn-error')
-      setColorInput('input-error')
-    }else{
-      handleResetEmail("reset-email")
+    if (requestStatus === "200" && showAlert === true) {
+      setColorButton("btn-success");
+    } else if (requestStatus === "404" && showAlert === true) {
+      setColorButton("btn-error");
+    } else {
+      handleResetEmail("reset-email");
     }
-  }, [showAlert])
-    
+  }, [showAlert]);
+
   return (
     <section className="lg:px-10 h-full flex flex-col">
-
       <div className="w-full hidden lg:block">
         <AdminButtons />
       </div>
 
-      <div className="flex flex-col place-items-center bg-white rounded-md h-full mb-10">
-        <h1 className="md:col-span-2 lg:col-span-3 font-black py-12 text-3xl font-poppins sm:text-center lg:text-left">{t("backofficePage.usersComponent.title")}</h1>
+      <div className="flex flex-col place-items-center bg-white rounded-xl h-full mb-10">
+        <h1 className="font-black py-12 text-3xl mt-28">
+          {t("backofficePage.usersComponent.title")}
+        </h1>
         <input
           type="email"
           ref={inputRef}
           disabled={desactivateInputElements}
-          onFocus={() => handleResetEmail('no-reset-email')}
+          onFocus={() => handleResetEmail("no-reset-email")}
           placeholder={t("backofficePage.usersComponent.emailInput")}
-          className={`flex my-8 input input-bordered ${colorInput} focus:outline-none w-2/3 max-w-xs`}
+          className={`my-8 input border border-neutral-300 focus:outline-none w-2/3 max-w-xs`}
           value={email}
           onChange={(e) => setEmail(e.target.value)}
         />
-        <div className="flex w-1/3">
-          <button   className={`btn w-full ${colorButton} text-white ${colorButton === 'btn-success' || colorButton === 'btn-error' ? 'pointer-events-none' : ''}`} onClick={handleSendEmail}>
-          {error === '' ? (
-            <span>{t("backofficePage.usersComponent.buttonTitle")}</span>
-          ) : error === "ERROR" ? (
-            <span>{t("backofficePage.usersComponent.emailIncorrect")}</span>
-          ) : showAlert === true && requestStatus==='200' ? (
-            <div className="flex items-center justify-items-center">
-              <img src={checkIcon} className="w-6" alt="OK" />
-              <p className="ml-2 font-bold normal-case"> {t("backofficePage.usersComponent.emailSendIt")} </p>
-            </div>
-          ) : showAlert === true && requestStatus!=='200' ? (
-            <div className="flex items-center justify-items-center">
-              <img src={errorIcon} className="w-6" alt="Error" />
-              <p className="ml-2 font-bold normal-case"> {t("backofficePage.usersComponent.emailNotSendIt")} </p>
-            </div>) :
-          (
-            <span className="loading loading-spinner"></span>
-          )}
-
+        <div className="flex w-2/3 max-w-xs">
+          <button
+            className={`btn w-full ${colorButton} text-white ${
+              isLoading ? "pointer-events-none" : ""
+            }`}
+            onClick={handleSendEmail}
+          >
+            {error === "" ? (
+              `${t("backofficePage.usersComponent.buttonTitle")}`
+            ) : error === "ERROR" ? (
+              `${t("backofficePage.usersComponent.emailIncorrect")}`
+            ) : showAlert && requestStatus === "200" ? (
+              <div className="flex items-center justify-items-center">
+                <img src={checkIcon} className="w-6" alt="OK" />
+                <p className="ml-2 font-bold normal-case">
+                  {t("backofficePage.usersComponent.emailSendIt")}
+                </p>
+              </div>
+            ) : showAlert && requestStatus !== "200" ? (
+              <div className="flex items-center justify-items-center">
+                <img src={errorIcon} className="w-6" alt="Error" />
+                <p className="ml-2 font-bold normal-case">
+                  {t("backofficePage.usersComponent.emailNotSendIt")}
+                </p>
+              </div>
+            ) : (
+              <span className="loading loading-spinner"></span>
+            )}
           </button>
-          {error === "ERROR" && (
-            <button className="btn btn-square btn-neutral ml-2" onClick={() => handleResetEmail('reset-email')}>
-              <img src={resetIcon} className="w-8" alt="resetIcon" />
-            </button>
-          )}
         </div>
-        {showAlert===true && requestStatus!=='200' &&
-          <p className="text-xs lg:w-1/3 w-1/2 mt-4 text-red-600">No se ha podido realizar la operación. Por favor, inténtelo más tarde</p>
-        }
+
+        {error === "ERROR" && (
+          <p className="text-base w-2/3 max-w-xs mt-4 text-red-600">
+            No se ha podido realizar la operación. Por favor, inténtelo más
+            tarde
+          </p>
+        )}
       </div>
     </section>
-  )
-}
+  );
+};
 
-export default BackOfficeUserSendCode
+export default BackOfficeUserSendCode;

--- a/src/components/BackOfficeUserSendCode.tsx
+++ b/src/components/BackOfficeUserSendCode.tsx
@@ -50,7 +50,7 @@ const BackOfficeUserSendCode = () => {
           handleResetEmail("reset-email");
           setIsLoading(false);
           setShowAlert(false);
-        }, 2000);
+        }, 1000);
       } catch (error) {
         handleResetEmail("reset-email");
         console.error(error);
@@ -63,7 +63,9 @@ const BackOfficeUserSendCode = () => {
 
   // when we focus on the input this happens
   const handleResetEmail = (resetEmail: string) => {
-    resetEmail === "reset-email" ? setEmail("") : "";
+    if (resetEmail === "reset-email") {
+      setEmail("");
+    }
     setDesactivateInputElements(false);
     setError("");
     setColorButton("bg-pink-it");


### PR DESCRIPTION
# Changes
- Updated layout to be more similar to the Figma

 ![image](https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/116231527/33bdfd74-9792-46e9-9c31-933355a1198b)
- The width for both the email Input and the Invite button is now fixed and the same in all screens.
- Removed the reset button. 
- Blocked extra api calls when there's one already pending.
- Red text when email is invalid now appears

![image](https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/116231527/02ca3a77-b43b-4680-bbbf-ef1d3c26343e)

*Prettier made some changes to make it more readable so that explains the extra changes on the file*
This PR fixes #123 