### PR TITLE
139-fix-responsive-login-modal

### DIFF
--- a/src/components/HeaderComponent.tsx
+++ b/src/components/HeaderComponent.tsx
@@ -112,7 +112,8 @@ const Header = () => {
         <div className="hidden lg:block   ">
           <button
             onClick={() => {
-              setIsDropdownOpen(false); setIsDropdownEnterButton(true);
+              setIsDropdownOpen(false);
+              setIsDropdownEnterButton(true);
             }}
             className="h-full flex btn btn-outline hover:bg-transparent hover:text-black"
           >
@@ -151,7 +152,7 @@ const Header = () => {
         {/* Menú desplegable para pantallas pequeñas */}
         {/* <div className="flex-grow flex justify-end items-center"> */}
         <div
-          className="lg:hidden m  flex-grow flex justify-end items-center"
+          className="lg:hidden flex-grow flex justify-end items-center"
           style={{ borderRadius: "10px" }}
         >
           <div
@@ -168,7 +169,7 @@ const Header = () => {
           {/* Desplegable Idiomas + Administración (pantallas pequeñas) */}
           {isDropdownOpen && (
             <>
-              <ul className=" z-50 lg:hidden justify-items-end bg-[#FFFF] absolute top-full  mt-16 mr-0 rounded-tl-xl rounded-bl-xl border-2 border-[#BDBDBD] ">
+              <ul className=" z-50 lg:hidden justify-items-end bg-[#FFFF] absolute top-full  mt-12 mr-0 rounded-tl-xl rounded-bl-xl border-2 border-[#BDBDBD] ">
                 <li className="flex items-center px-8 py-8 ml-4 mt-6 hover:bg-gray-200 flex-row text-[#7E7E7E]">
                   <div className="text-left flex-grow">
                     <div className="rounded-full h-53 w-53 flex items-left text-black font-bold text-2xl">
@@ -176,25 +177,38 @@ const Header = () => {
                     </div>
                   </div>
                 </li>
-                <li className="flex items-center px-8 py-4 ml-4    cursor-pointer    lg:hover:bg-gray-200 flex-row">
+                <li className="flex items-center px-8 py-4 ml-4 cursor-pointer lg:hover:bg-gray-200 flex-row">
                   <div className="text-left flex-grow ml-2 text-gray-600 text-2xl text-[#7E7E7E]">
-                    <h3 className=" hover:border-b-4 hover:border-blue-800">
+                    <button
+                      className=" hover:border-b-4 hover:border-blue-800"
+                      onClick={() => handleChangeLanguageOfTheWebsite("catala")}
+                    >
                       Català
-                    </h3>
+                    </button>
                   </div>
                 </li>
                 <li className="flex items-center px-8 py-2 ml-4 lg:hover:bg-gray-200 flex-row cursor-pointer">
                   <div className="text-left flex-grow ml-2 text-gray-600 text-2xl text-[#7E7E7E]">
-                    <h3 className=" hover:border-b-4 hover:border-blue-800">
+                    <button
+                      className=" hover:border-b-4 hover:border-blue-800"
+                      onClick={() =>
+                        handleChangeLanguageOfTheWebsite("espanol")
+                      }
+                    >
                       Castellano
-                    </h3>
+                    </button>
                   </div>
                 </li>
                 <li className="flex items-center px-8 py-2 ml-4 lg:hover:bg-gray-200 flex-row cursor-pointer">
                   <div className="text-left flex-grow ml-2 text-gray-600 text-2xl text-[#7E7E7E]">
-                    <h3 className=" hover:border-b-4 hover:border-blue-800">
+                    <button
+                      className=" hover:border-b-4 hover:border-blue-800"
+                      onClick={() =>
+                        handleChangeLanguageOfTheWebsite("english")
+                      }
+                    >
                       English
-                    </h3>
+                    </button>
                   </div>
                 </li>
                 <li className="flex items-center px-8 py-8 ml-4 mr-8 mt-6 hover:bg-gray-200 flex-row">
@@ -209,6 +223,10 @@ const Header = () => {
                   <button
                     className="bg-transparent transparent px-4 py-2 ml-12 mb-8 mt-0 flex items-center"
                     style={{ borderRadius: "10px", border: "1px solid black" }}
+                    onClick={() => {
+                      setIsDropdownOpen(false);
+                      setIsDropdownEnterButton(true);
+                    }}
                   >
                     <div className="ml-2 mt-4 mb-4">
                       <img src={selector} className="h-8 w-8" />

--- a/src/components/LoginComponent.tsx
+++ b/src/components/LoginComponent.tsx
@@ -36,7 +36,10 @@ export default function LoginComponent({
         className={`absolute z-50 right-0 top-full mt-6 w-80 rounded-xl bg-white border-2 `}
       >
         <div className="p-3">
-          <button onClick={() => setIsDropdownEnterButton(false)} className="float-right ">
+          <button
+            onClick={() => setIsDropdownEnterButton(false)}
+            className="float-right "
+          >
             <img src={cross} className="cursor-pointer w-3 ml-auto " alt="" />
           </button>
         </div>
@@ -57,25 +60,6 @@ export default function LoginComponent({
               placeholder={t("landingPage.loginModal.passwordInput")}
             />
 
-            <div className="text-xs text-end">
-              <button
-                className="border-b-2 border-black"
-                onClick={() => {
-                  dispatch(
-                    passwordReminderReducer({
-                      type: "SHOW_PASSWORD_REMINDER",
-                    })
-                  );
-                  dispatch(eraseMessageError());
-                  setIsDropdownEnterButton(false);
-                  setisDropdownCuenta(false);
-                  setIsPasswordReminder(true);
-                }}
-              >
-                {t("landingPage.loginModal.changePassword")}
-              </button>
-            </div>
-
             <button
               type="submit"
               className="mt-5 btn btn-block bg-pink-it text-white"
@@ -91,11 +75,30 @@ export default function LoginComponent({
               )}
             </button>
           </form>
+          <div className="text-xs text-end">
+            <button
+              className="border-b-2 border-black"
+              onClick={() => {
+                dispatch(
+                  passwordReminderReducer({
+                    type: "SHOW_PASSWORD_REMINDER",
+                  })
+                );
+                dispatch(eraseMessageError());
+                setIsDropdownEnterButton(false);
+                setisDropdownCuenta(false);
+                setIsPasswordReminder(true);
+              }}
+            >
+              {t("landingPage.loginModal.changePassword")}
+            </button>
+          </div>
           <div className="text-xs mt-5 ">
             <button
               onClick={() => {
                 dispatch(eraseMessageError());
-                setIsDropdownEnterButton(false); setisDropdownCuenta(true);
+                setIsDropdownEnterButton(false);
+                setisDropdownCuenta(true);
               }}
               className="border-b-2 border-black"
             >

--- a/src/components/faqs/FAQsComponent.tsx
+++ b/src/components/faqs/FAQsComponent.tsx
@@ -112,7 +112,6 @@ const FAQs = () => {
 
   return (
     <section className="flex flex-col h-auto lg:pr-10 py-2">
-
       <div className="w-full h-full px-8 bg-white rounded-xl mb-10">
         {window.location.pathname === "/" && (
           <h2 className="font-bold mb-6 text-4xl text-center">
@@ -135,11 +134,11 @@ const FAQs = () => {
               className={`collapse rounded-lg mb-5 shadow-[0_2px_6px_rgba(70,70,70,0.2)] border-[1px] `}
             >
               <input type="checkbox" className="peer" id={index.toString()} />
-              <div className="collapse-title relative lg:flex items-center rounded-b-md bg-white text-justify text-[#092C4C] text-4 font-poppins font-bold peer-checked:bg-[#BA007C] peer-checked:rounded-b-[0px] peer-checked:text-[#fff] h-[62px]">
+              <div className="collapse-title relative lg:flex rounded-b-md bg-white items-center text-[#092C4C] font-poppins font-bold peer-checked:bg-[#BA007C] peer-checked:rounded-b-[0px] peer-checked:text-[#fff] min-h-12">
                 {window.location.pathname == "/backoffice" &&
                 isContentEditing &&
                 index.toString() === positionIndex ? (
-                  <div className="flex items-center w-full">
+                  <div className="flex w-full">
                     <input
                       type="text"
                       className="z-10 content-center flex-grow pl-2 text-white input input-ghost"
@@ -149,15 +148,13 @@ const FAQs = () => {
                     />
                   </div>
                 ) : (
-                  <p className="lg:text-justify sm:text-center max-w-[75%] ">
-                    {faqsClone[index].title}
-                  </p>
+                  <p className="text-left">{faqsClone[index].title}</p>
                 )}
 
                 {/*Buttons editar/eliminar sin desplegar   */}
 
                 {window.location.pathname == "/backoffice" && titleButtons && (
-                  <div className="relative z-10 flex justify-end mt-8 ml-auto lg:mt-0">
+                  <div className="relative z-10 flex justify-end mt-3 ml-auto lg:mt-0">
                     <button
                       className="mx-4 px-4 text-[#808080] font-semibold border bg-white border-[#D9D9D9] rounded-lg h-[30px] self-center"
                       onClick={() => displayInput(index, faqsClone[index])}
@@ -186,7 +183,7 @@ const FAQs = () => {
               {/*Edit: area texto  */}
 
               <div className="collapse-content rounded-b-md">
-                <p className="py-4 mx-0 my-6 leading-relaxed text-justify text-[#092C4C] text-4 font-poppins">
+                <p className="py-4 mx-0 my-6 leading-relaxed text-left text-[#092C4C] text-4 font-poppins">
                   {window.location.pathname == "/backoffice" &&
                   isContentEditing &&
                   index.toString() === positionIndex ? (


### PR DESCRIPTION
# Changes
- Login modal now is visible in small screens

![image](https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/116231527/7a862358-d797-4087-8c1b-4135648702a0)

## Other small fixes
- Moved the remember password component outside the login form. Now when we fill the login fields and press `Enter` the user logins as expected and doesn't open the remember password component.
- Fixed FAQs components, now the text is readable and buttons visible.

 From this:
![image](https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/116231527/20915a2f-dbd2-4c47-a3c0-505fde5b3e6b)

To this:
![image](https://github.com/IT-Academy-BCN/ita-landing-frontend/assets/116231527/f50e0103-1eb3-485e-abee-fdc5b7f48a0f)
